### PR TITLE
Add timestamp to CredRecord struct

### DIFF
--- a/Credential.sol
+++ b/Credential.sol
@@ -8,6 +8,7 @@ contract Credential is Ownable {
   struct CredRecord {
     bytes32 contentHash;
     bool valid;
+    string timestamp;
   }
 
 
@@ -25,10 +26,8 @@ contract Credential is Ownable {
     _;
   }
 
-  //private function to add credential
-
-  function addCredential(bytes32 _credHash) public onlyOwner() {
-    credentials[_credHash] = CredRecord({contentHash:_credHash, valid:true});
+  function addCredential(bytes32 _credHash, string _credTimestamp) public onlyOwner() {
+    credentials[_credHash] = CredRecord({contentHash:_credHash, valid:true, timestamp:_credTimestamp});
     emit CredentialAdded(_credHash);
   }
 
@@ -49,7 +48,7 @@ contract Credential is Ownable {
     return true;
   }
 
-  function validateCredential(byte32 _credHash) public onlyOwner() returns(bool) {
+  function validateCredential(bytes32 _credHash) public onlyOwner() returns(bool) {
     credentials[_credHash].valid = true;
     require(credentials[_credHash].valid == true, "Credential has not been changed to valid");
     return true;

--- a/Ownable.sol
+++ b/Ownable.sol
@@ -1,5 +1,3 @@
-
-
 pragma solidity 0.4.24;
 
 /**


### PR DESCRIPTION
# Description

Adds a `timestamp` field to the `CredRecord` struct for storing the exact time that a new credential was added. This includes the necessary update to the function for adding new credentials. A pull request with matching changes has also been made in the back end repository.

## Checklist

- [X] I have performed a self-review of my own code